### PR TITLE
Updated test file to align with Readme

### DIFF
--- a/project.test.js
+++ b/project.test.js
@@ -120,8 +120,8 @@ describe('server.js', () => {
       expect(res.body.message).toMatch(/provide title and contents/i)
       updates = {}
       res = await request(server).put(`/api/posts/${id}`).send(updates)
-      expect(res.status).toBe(400)
-      expect(res.body.message).toMatch(/provide title and contents/i)
+      expect(res.status).toBe(500)
+      expect(res.body.message).toMatch(/The post information could not be modified/i)
     }, 500)
   })
   describe('5 [DELETE] /api/posts/:id', () => {


### PR DESCRIPTION
Updated test file to reflect specs in Readme. I'm pretty sure it was just a copy/paste mistake.

Readme states:
#### 4 [PUT] /api/posts/:id

- If the _post_ with the specified `id` is not found:

  - return HTTP status code `404` (Not Found).
  - return the following JSON: `{ message: "The post with the specified ID does not exist" }`.

- If the request body is missing the `title` or `contents` property:

  - respond with HTTP status code `400` (Bad Request).
  - return the following JSON: `{ message: "Please provide title and contents for the post" }`.

- If there's an error when updating the _post_:

  - respond with HTTP status code `500`. <----- Corrected test to reflect this not "400" as originally written
  - return the following JSON: `{ message: "The post information could not be modified" }`. < ----- Corrected test to reflect this not "provide title and contents" as 
                                                                                                                                                                          originally written.

- If the post is found and the new information is valid:

  - update the post document in the database using the new information sent in the `request body`.
  - return HTTP status code `200` (OK).
  - return the newly updated _post_.